### PR TITLE
Add company-phpactor backend

### DIFF
--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -1,0 +1,37 @@
+;;; company-phpactor.el --- Phpactor backend for company -*- lexical-binding t; -*-
+
+;; Copyright (C) 2018  Friends of Emacs-PHP development
+
+;; Author: MARTIN tang <martin.tang365@gmail.com>
+;; Created: 18 Apr 2018
+;; Version: 0.0.1
+;; Keywords: tools, php
+;; Package-Requires: ((emacs "24") (cl-lib "0.5") (company "0.9.6"))
+;; URL: https://github.com/emacs-php/phpactor.el
+;; License: GPL-3.0-or-later
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+(require 'company)
+(require 'phpactor)
+
+(defun company-phpactor (command &optional arg &rest ignored)
+  (interactive (list 'interactive))
+  (cl-case command
+    (interactive (company-begin-backend 'company-phpactor))
+    (prefix (company-grab-symbol))
+    (candidates (let* ((offset (point))
+                       (response (phpactor--rpc "complete" (list :source (buffer-substring 1 offset) :offset offset))))
+                  (mapcar (lambda (x) (plist-get x :name)) (plist-get (plist-get (plist-get response :parameters) :value) :suggestions))))))
+

--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -35,3 +35,5 @@
                        (response (phpactor--rpc "complete" (list :source (buffer-substring 1 offset) :offset offset))))
                   (mapcar (lambda (x) (plist-get x :name)) (plist-get (plist-get (plist-get response :parameters) :value) :suggestions))))))
 
+(provide 'company-phpactor)
+;;; company-phpactor.el ends here

--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2018  Friends of Emacs-PHP development
 
-;; Author: MARTIN tang <martin.tang365@gmail.com>
+;; Author: Martin Tang <martin.tang365@gmail.com>
 ;; Created: 18 Apr 2018
 ;; Version: 0.0.1
 ;; Keywords: tools, php


### PR DESCRIPTION
If you aren't familiar with `company`, the usage should just be by calling `M-x company-phpactor` with cursor at the point you want to start autocompletion.

I've tested this with a method call e.g.
```php
<?php
$e = new Exception();
$e->
```
and it seemed to work, but I haven't tried it for any other examples.

I think what I've done looks quite messy - please don't hesitate to give me constructive criticism (even if I have to change everything!).