### PR TITLE
send buffer content without properties to phpactor

### DIFF
--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -38,7 +38,7 @@
     (interactive (company-begin-backend 'company-phpactor))
     (prefix (company-grab-symbol))
     (candidates (let* ((offset (point))
-                       (response (phpactor--rpc "complete" (list :source (buffer-substring 1 offset) :offset offset))))
+                       (response (phpactor--rpc "complete" (list :source (buffer-substring-no-properties 1 offset) :offset offset))))
                   (mapcar (lambda (x) (plist-get x :name)) (plist-get (plist-get (plist-get response :parameters) :value) :suggestions))))))
 
 (provide 'company-phpactor)


### PR DESCRIPTION
use of buffer-substring-no-properties  instead of buffer-substring : this seems to fix issue https://github.com/emacs-php/phpactor.el/issues/8