### PR TITLE
Rename `phpactor-action--error` to `phpactor-action-error`

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -135,7 +135,7 @@
     (replace_file_source . phpactor-action-replace-file-source)))
 
 ;; Helper functions:
-(defmacro phpactor-action--error (&rest args)
+(defmacro phpactor-action-error (&rest args)
   "Signal an error, noticed from Phpactor by `ARGS'."
   (cons (if (fboundp 'user-error) #'user-error #'error)
         args))


### PR DESCRIPTION
This should fix #5

But should all these functions/macros/variables be prefixed with
`phpactor-action--` ? or even `phpactor--action-`?