### PR TITLE
Use phpactor--command-argments in company-phpactor--get-suggestions

### DIFF
--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -31,9 +31,9 @@
 (require 'company)
 (require 'phpactor)
 
-(defun company-phpactor--get-suggestions (source offset)
+(defun company-phpactor--get-suggestions ()
   "Get completions for current cursor."
-  (let ((response (phpactor--rpc "complete" (list :source (buffer-substring-no-properties (point-min) (point-max)) :offset (point)))))
+  (let ((response (phpactor--rpc "complete" (phpactor--command-argments :source :offset))))
     (plist-get (plist-get (plist-get response  :parameters) :value) :suggestions)))
 
 ;;;###autoload
@@ -43,9 +43,7 @@
   (cl-case command
     (interactive (company-begin-backend 'company-phpactor))
     (prefix (company-grab-symbol))
-    (candidates (let ((offset (point))
-                      (source (buffer-substring-no-properties (point-min) (point-max))))
-                  (all-completions arg (mapcar #'(lambda (suggestion) (plist-get suggestion :name)) (company-phpactor--get-suggestions source offset)))))))
+    (candidates (all-completions arg (mapcar #'(lambda (suggestion) (plist-get suggestion :name)) (company-phpactor--get-suggestions))))))
 
 (provide 'company-phpactor)
 ;;; company-phpactor.el ends here


### PR DESCRIPTION
Previously, the function `company-phpactor--get-suggestions` took two variables, SOURCE and OFFSET, but didn't even use them (I forgot to implement the changes). Now the function uses `phpactor--command-argments`

What worries me now is that I think this makes it slightly less testable? But perhaps the package is small enough that it won't be an issue.