### PR TITLE
use argument of company-phpactor--get-suggestions

### DIFF
--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -33,7 +33,7 @@
 
 (defun company-phpactor--get-suggestions (source offset)
   "Get completions for current cursor."
-  (let ((response (phpactor--rpc "complete" (list :source (buffer-substring-no-properties (point-min) (point-max)) :offset (point)))))
+  (let ((response (phpactor--rpc "complete" (list :source (buffer-substring-no-properties (point-min) (point-max)) :offset (offset)))))
     (plist-get (plist-get (plist-get response  :parameters) :value) :suggestions)))
 
 ;;;###autoload

--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -33,7 +33,7 @@
 
 (defun company-phpactor--get-suggestions (source offset)
   "Get completions for current cursor."
-  (let ((response (phpactor--rpc "complete" (list :source (buffer-substring-no-properties (point-min) (point-max)) :offset offset))))
+  (let ((response (phpactor--rpc "complete" (list :source source :offset offset))))
     (plist-get (plist-get (plist-get response  :parameters) :value) :suggestions)))
 
 ;;;###autoload

--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -33,7 +33,7 @@
 
 (defun company-phpactor--get-suggestions (source offset)
   "Get completions for current cursor."
-  (let ((response (phpactor--rpc "complete" (list :source (buffer-substring-no-properties (point-min) (point-max)) :offset (offset)))))
+  (let ((response (phpactor--rpc "complete" (list :source (buffer-substring-no-properties (point-min) (point-max)) :offset offset))))
     (plist-get (plist-get (plist-get response  :parameters) :value) :suggestions)))
 
 ;;;###autoload


### PR DESCRIPTION
offset argument was not used as it probably was meant.

This should not change anything in the behaviour, but will be useful when [some processing like here](https://github.com/phpactor/phpactor/blob/76ef37b4463da1ae6c8a93af74ff27010c11ab4e/plugin/phpactor.vim#L53) will be in place for this offset argument (