### PR TITLE
Use absolute path for navigate

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -311,14 +311,14 @@
 (defun phpactor-navigate ()
   "Execute Phpactor RPC navigate command."
   (interactive)
-  (let ((arguments (list :source_path (file-relative-name buffer-file-name
+  (let ((arguments (list :source_path (expand-file-name buffer-file-name
                                                           (phpactor-get-working-dir)))))
     (apply #'phpactor-action-dispatch (phpactor--rpc "navigate" arguments))))
 
 ;;;###autoload
 (defun phpactor-echo (message)
   "Execute Phpactor RPC echo command, say `MESSAGE'."
-  (interactive "MInput Message: ")
+  (interactive "Input Message: ")
   (let ((phpactor-action--message-format "Message from Phpactor: %s"))
     (apply #'phpactor-action-dispatch (phpactor--rpc "echo" (list :message message)))))
 


### PR DESCRIPTION
The navigate handler was being passed a relative path, which doesn't always work very well, not sure why this one was relative, all the rest seem to be absolute.