### PR TITLE
add specific company-phpactor--grab-symbol function

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -121,6 +121,7 @@
         (json-object-type 'plist)
         (json-array-type 'list)
         (output (get-buffer-create "*Phpactor Output*")))
+    (with-current-buffer output (erase-buffer))
     (with-current-buffer (get-buffer-create "*Phpactor Input*")
       (erase-buffer)
       (insert json)


### PR DESCRIPTION
$ symbol has to be present in the prefix in order to match phpactor's
suggestions. Thus, we need a specific function to extract this prefix.

see [issue 28](https://github.com/emacs-php/phpactor.el/issues/28)