### PR TITLE
replace shell-command-on-region by call-process-region

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -130,7 +130,7 @@
     (with-current-buffer (get-buffer-create "*Phpactor Input*")
       (erase-buffer)
       (insert json)
-      (shell-command-on-region (point-min) (point-max) cmd output)
+      (call-process-region (point-min) (point-max) (phpactor-find-executable) nil output nil "rpc" (format "--working-dir=%s" (phpactor-get-working-dir)))
       (with-current-buffer output
         (goto-char (point-min))
         (json-read-object)))))


### PR DESCRIPTION
shell-command-on-region is meant for interactive use, causing a buffer
to popup now and then. This commit removes this disturbing behaviour.