### PR TITLE
WIP: add annotation beside completion candidate

### DIFF
--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -52,16 +52,13 @@ Here we create a temporary syntax table in order to add $ to symbols."
 
 (defun company-phpactor--get-candidates ()
   "Build a list of candidates with text-properties extracted from phpactor's output."
-  (let ((suggestions (company-phpactor--get-suggestions))
-        (candidates ()))
-    (while suggestions
-      (setq suggestion (car suggestions))
-      (setq candidate (plist-get suggestion :name))
-      (put-text-property 0 1 'annotation (plist-get suggestion :info) candidate)
-      (add-to-list 'candidates candidate)
-      (setq suggestions (cdr suggestions))
-      )
-    candidates))
+  (let ((suggestions (company-phpactor--get-suggestions)))
+    (mapcar
+     (lambda (suggestion)
+       (setq candidate (plist-get suggestion :name))
+       (put-text-property 0 1 'annotation (plist-get suggestion :info) candidate)
+       candidate)
+     suggestions)))
 (defun company-phpactor--annotation (arg)
   "test annotation."
   (message (concat " " (get-text-property 0 'annotation arg))))

--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -50,14 +50,31 @@ Here we create a temporary syntax table in order to add $ to symbols."
   (let ((response (phpactor--rpc "complete" (phpactor--command-argments :source :offset))))
     (plist-get (plist-get (plist-get response  :parameters) :value) :suggestions)))
 
+(defun company-phpactor--get-candidates ()
+  "Build a list of candidates with text-properties extracted from phpactor's output."
+  (let ((suggestions (company-phpactor--get-suggestions))
+        (candidates ()))
+    (while suggestions
+      (setq suggestion (car suggestions))
+      (setq candidate (plist-get suggestion :name))
+      (put-text-property 0 1 'annotation (plist-get suggestion :info) candidate)
+      (add-to-list 'candidates candidate)
+      (setq suggestions (cdr suggestions))
+      )
+    candidates))
+(defun company-phpactor--annotation (arg)
+  "test annotation."
+  (message (concat " " (get-text-property 0 'annotation arg))))
+
 ;;;###autoload
 (defun company-phpactor (command &optional arg &rest ignored)
   "`company-mode' completion backend for Phpactor."
   (interactive (list 'interactive))
   (cl-case command
+    (annotation (company-phpactor--annotation arg))
     (interactive (company-begin-backend 'company-phpactor))
     (prefix (company-phpactor--grab-symbol))
-    (candidates (all-completions (substring-no-properties arg) (mapcar #'(lambda (suggestion) (plist-get suggestion :name)) (company-phpactor--get-suggestions))))))
+    (candidates (all-completions arg (company-phpactor--get-candidates)))))
 
 (provide 'company-phpactor)
 ;;; company-phpactor.el ends here


### PR DESCRIPTION
Follows reflextions posted [here](https://github.com/emacs-php/phpactor.el/issues/32)

annotation is directly taken from phpactor's ``info`` key

![image](https://user-images.githubusercontent.com/10561580/43047357-d60844f4-8dde-11e8-8475-4fe609094017.png)

I've just written this and have already consumed too much time :-) So this PR probably deserves a review and a bit of testing before merging ;-)