### PR TITLE
Use position-bytes function instead of point

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -216,7 +216,7 @@
               (point-min) (point-max)))
     (:path (phpactor--expand-local-file-name buffer-file-name))
     (:source_path (phpactor--expand-local-file-name buffer-file-name))
-    (:offset (1- (point)))
+    (:offset (1- (position-bytes (point))))
     (:current_path (phpactor--expand-local-file-name buffer-file-name))
     (t (error "`%s' is unknown argument" key))))
 


### PR DESCRIPTION
I thought this was intuitively a problem of [phpactor/worse-reflection](https://github.com/phpactor/worse-reflection), but in fact it is a problem of [Tolerant PHP Parser](https://github.com/Microsoft/tolerant-php-parser).

In modern environments it is obsolete to operate in byte units instead of character units, but Tolerant PHP Parser's current implementation adopt byte offsets.