### PR TITLE
add a function to execute directly "complete_constructor" transform

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -498,5 +498,12 @@ function."
   (let ((arguments (phpactor--command-argments :source :offset :path)))
     (apply #'phpactor-action-dispatch (phpactor--rpc "import_class" (append arguments (list :name name))))))
 
+;;;###autoload
+(defun phpactor-complete-constructor ()
+  "Execute Phpactor PRC transform command to complete_constructor."
+  (interactive)
+  (let ((arguments (phpactor--command-argments :source :path)))
+    (apply #'phpactor-action-dispatch (phpactor--rpc "transform" (append arguments (list :transform "complete_constructor"))))))
+
 (provide 'phpactor)
 ;;; phpactor.el ends here


### PR DESCRIPTION
This PR adds a dedicated function to execute the "complete_constructor" transform.

"complete_constructor" is already available through the context menu which is fine, but having a dedicated function can also be useful (for keybindings for example).