### PR TITLE
WIP: toggle completion caching whether number of candidates reaches limit

### DIFF
--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -32,6 +32,11 @@
 (require 'company)
 (require 'phpactor)
 
+; this should have the same value as phpactor's completion.completor.class.limit value
+; by default, phpactor sets this to 100
+(defvar company-phpactor--completion-limit 100)
+(defvar company-phpactor--ignore-cache nil)
+
 (defun company-phpactor--grab-symbol ()
   "If point is at the end of a symbol, return it.
 Otherwise, if point is not inside a symbol, return an empty string.
@@ -54,6 +59,7 @@ Here we create a temporary syntax table in order to add $ to symbols."
 (defun company-phpactor--get-candidates ()
   "Build a list of candidates with text-properties extracted from phpactor's output."
   (let ((suggestions (company-phpactor--get-suggestions)) candidate)
+    (setq company-phpactor--ignore-cache (= (length suggestions) company-phpactor--completion-limit))
     (mapcar
      (lambda (suggestion)
        (setq candidate (plist-get suggestion :name))
@@ -80,6 +86,7 @@ Here we create a temporary syntax table in order to add $ to symbols."
   (save-restriction
     (widen)
     (cl-case command
+      (no-cache company-phpactor--ignore-cache)
       (post-completion (company-phpactor--post-completion arg))
       (annotation (company-phpactor--annotation arg))
       (interactive (company-begin-backend 'company-phpactor))


### PR DESCRIPTION
if the number of suggested candidates reaches the limit, the desired
candidate might be missing.

If that occurs, caching should not be used when typing more characters
of the completed string, as phpactor will be invoked with a longer
prefix, and have more chances to return the desired candidate.

fixes #50 

EDIT : this still needs to be tested. I'll try to use test this in a near future by lowering phpactor's `completion.completor.class.limit` value in order to trigger that code more often