### PR TITLE
install phpactor with phpactor-update function

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,13 +3,20 @@ This package is Emacs interface to [[http://phpactor.github.io/phpactor/][Phpact
 
 *NOTICE*: This package is in development.  Since some functions are running, this is released as an /alpha version/.
 
+*NOTICE*: Phpactor is also in development stage.
+
 #+BEGIN_HTML
 <a href="http://melpa.org/#/phpactor"><img alt="MELPA: phpactor" src="http://melpa.org/packages/phpactor-badge.svg"></a>
 <a href="http://stable.melpa.org/#/phpactor"><img alt="MELPA stable: phpactor" src="http://stable.melpa.org/packages/phpactor-badge.svg"></a>
 #+END_HTML
 ** Instalation
-Please be aware that Phpactor is also in development stage.
-A simple installation method is not yet provided, but you can build it using Composer.
+
+After having installed this package, run `phpactor-update` (this will install a supported version of phpactor inside phpactor.el's installation folder).
+*NOTICE*: To ensure the appropriate version of Phpactor is installed, please run this command after every upgrade of phpactor.el
+
+Alternatively, you can install Phpactor on your own and configure `phpactor-executable` but please be aware that any change in Phpactor's rpc protocol can introduce breakages.
+
+
 ** Configuration
 See https://phpactor.github.io/phpactor/configuration.html
 

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,8 @@
         "sebastian/diff": "@dev"
     },
     "config": {
-         "sort-packages": true
+        "optimize-autoloader": true,
+        "classmap-authoritative": true,
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
The recent evolutions in phpactor's rpc protocol made me realize that non BC changes could also break the correction operation of this package (ie `version` and `force_reload` new parameters).

Thus, I believe the simplest and safest approach to install phpactor *for its use from phpactor.el* is to have it installed from phpactor.el (with its version controlled  in composer.json).

I would also qualify the use of an externally installed phpactor as risky, and therefore require the user to configure ``phpactor-executable`` manually in order to draw attention on this.

solves #59 