### PR TITLE
Add a function to search Phpactor RPC documentation

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -492,6 +492,13 @@ function."
 ;; See https://phpactor.github.io/phpactor/rpc.html#phpactor-commands
 
 ;;;###autoload
+(defun phpactor-open-rpc-documentation (command)
+  "Open the official documentation for COMMAND."
+  (interactive "sRPC Command: ")
+  (let ((doc-uri (concat "https://github.com/phpactor/phpactor/blob/develop/doc/rpc.md#" command)))
+    (browse-url doc-uri)))
+
+;;;###autoload
 (defun phpactor-copy-class ()
   "Execute Phpactor RPC copy_class command."
   (interactive)


### PR DESCRIPTION
This patch provides an interactive function which will prompt the
user for the name of one of Phpactor's RPC commands, and will proceed
to open the user's browser to the documentation on that command.
For the documentation we use the Phpactor GitHub page because
it's Markdown document of RPC commands contains hyperlinks to each
individual command.

In the future we should probably restrict the possible inputs to
only those command names which are valid.  However, that assumes that
`phpactor.el` has a built-in list of valid commands.  If not, or if
we decide we do not wish to maintain such a list, then we should not
bother with this addition.

Finally, this patch does not update the README with any mention of
the new function as I could not think of a succinct way to describe it.

Signed-off-by: Eric James Michael Ritz <ejmr@no.current.address>