### PR TITLE
Avoid use of context_menu rpc action for generate_accessor action

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -737,8 +737,8 @@ function."
 (defun phpactor-generate-accessors ()
   "Execute Phpactor PRC generate_accessor action."
   (interactive)
-  (let ((arguments (phpactor--command-argments :current_path :offset :source)))
-    (apply #'phpactor-action-dispatch (phpactor--rpc "context_menu" (append arguments (list :action "generate_accessor"))))))
+  (let ((arguments (phpactor--command-argments :path :offset :source)))
+    (apply #'phpactor-action-dispatch (phpactor--rpc "generate_accessor" arguments))))
 
 ;;;###autoload
 (defun phpactor-add-missing-assignments ()


### PR DESCRIPTION
Use of `context_menu` rpc action was a temporary solution for bug https://github.com/phpactor/phpactor/issues/622

This bug being fixed, we should be able to use `generate_accessor` directly on next release.