### PR TITLE
Fix (let default-directory) instead of setq it

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -99,8 +99,8 @@
   (let ((package-folder (phpactor--get-package-directory))
         (composer-executable (car (composer--find-executable))))
     (unless composer-executable (error "`composer' not found"))
-    (setq default-directory package-folder)
-    (call-process composer-executable nil (get-buffer-create phpactor--buffer-name) nil "install" "--no-dev")))
+    (let ((default-directory package-folder))
+      (call-process composer-executable nil (get-buffer-create phpactor--buffer-name) nil "install" "--no-dev"))))
 
 (defun phpactor--get-package-directory ()
   "Return the folder where phpactor.el is installed."


### PR DESCRIPTION
The default-directory must be set locally. People setting up Phpactor while editing will feel that behavior suspiciously. Since let binds variables only within that block, do not need to kill the buffer.