### PR TITLE
Add support for add_missing_assignments transform

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -748,5 +748,12 @@ function."
   (let ((arguments (phpactor--command-argments :current_path :offset :source)))
     (apply #'phpactor-action-dispatch (phpactor--rpc "context_menu" (append arguments (list :action "generate_accessor"))))))
 
+;;;###autoload
+(defun phpactor-add-missing-assignments ()
+  "Execute Phpactor PRC add_missing_assignments action."
+  (interactive)
+  (let ((arguments (phpactor--command-argments :source :path)))
+    (apply #'phpactor-action-dispatch (phpactor--rpc "transform" (append arguments (list :transform "add_missing_properties"))))))
+
 (provide 'phpactor)
 ;;; phpactor.el ends here


### PR DESCRIPTION
Before and After
```php
<?php

class AcmeBlogTest extends TestCase
{
    public function setUp()
    {
        $this->blog = new Blog();
    }
}
```
Becomes:
```php
<?php

class AcmeBlogTest extends TestCase
{
    /**
     * @var Blog
     */
    private $blog;

    public function setUp()
    {
        $this->blog = new Blog();
    }
}
```