### PR TITLE
Map replace_file_source to phpactor-action-update-file-source

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -242,6 +242,7 @@ of GitHub.")
     (file_references . phpactor-action-file-references)
     (input_callback . phpactor-action-input-callback)
     (information . phpactor-action-information)
+    (replace_file_source . phpactor-action-update-file-source)
     (update_file_source . phpactor-action-update-file-source)))
 
 ;; Helper functions:


### PR DESCRIPTION
It was too soon to remove replace_file_source as it is sometimes
invoked from a callback

For example, `replace_file_source` was invoked during the `class_new` contextual operation.