### PR TITLE
check phpactor-find-executable before completion

### DIFF
--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -79,14 +79,15 @@ Here we create a temporary syntax table in order to add $ to symbols."
 (defun company-phpactor (command &optional arg &rest ignored)
   "`company-mode' completion backend for Phpactor."
   (interactive (list 'interactive))
-  (save-restriction
-    (widen)
-    (pcase command
-      (`post-completion (company-phpactor--post-completion arg))
-      (`annotation (company-phpactor--annotation arg))
-      (`interactive (company-begin-backend 'company-phpactor))
-      (`prefix (company-phpactor--grab-symbol))
-      (`candidates (all-completions arg (company-phpactor--get-candidates))))))
+  (when (phpactor-find-executable)
+    (save-restriction
+      (widen)
+      (pcase command
+        (`post-completion (company-phpactor--post-completion arg))
+        (`annotation (company-phpactor--annotation arg))
+        (`interactive (company-begin-backend 'company-phpactor))
+        (`prefix (company-phpactor--grab-symbol))
+        (`candidates (company-phpactor--get-candidates))))))
 
 (provide 'company-phpactor)
 ;;; company-phpactor.el ends here


### PR DESCRIPTION
I stumbled on this [comment](https://github.com/hlissner/doom-emacs/blob/4028f36beb9c1fdd2dc9557f4dda640cb8f7807a/modules/lang/php/config.el#L43).

By the way, I wondered if it could be a bit simpler (and optimized) to merge phpactor-executable and phpactor-find-executable using `defcustom`. That way, the expression in charge of locating the executable would be evaluated only once, and still customizable by the end user.