### PR TITLE
return default-directory when php-project-get-root-dir fails

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -155,7 +155,8 @@ of GitHub.")
 (defun phpactor-get-working-dir ()
   "Return working directory of Phpactor."
   (directory-file-name
-   (expand-file-name (php-project-get-root-dir))))
+   (expand-file-name
+    (or (php-project-get-root-dir) default-directory))))
 
 (defun phpactor--expand-local-file-name (name)
   "Expand file name by `NAME'."


### PR DESCRIPTION
without working-directory, phpactor isn't very helpful.

inspiration [herefrom](https://github.com/hlissner/doom-emacs/blob/4028f36beb9c1fdd2dc9557f4dda640cb8f7807a/modules/lang/php/config.el#L50)