### PR TITLE
declare phpactor-executable as defcustom (take two)

### DIFF
--- a/README.org
+++ b/README.org
@@ -42,8 +42,7 @@ This package is Emacs interface to [[http://phpactor.github.io/phpactor/][Phpact
 
  *NOTICE*: To ensure the supported version of Phpactor is installed, you might need to run this command again after an upgrade of this package.
 
- Alternatively, you can install Phpactor on your own and configure `phpactor-executable` but please be aware that any change in Phpactor's rpc protocol can introduce breakages.
-
+Alternatively, you can install Phpactor on your own and customize `phpactor-executable` but please be aware that any change in Phpactor's rpc protocol can introduce breakages.
 
 ** Configuration
 *** completion

--- a/company-phpactor.el
+++ b/company-phpactor.el
@@ -79,7 +79,7 @@ Here we create a temporary syntax table in order to add $ to symbols."
 (defun company-phpactor (command &optional arg &rest ignored)
   "`company-mode' completion backend for Phpactor."
   (interactive (list 'interactive))
-  (when (phpactor-find-executable)
+  (when phpactor-executable
     (save-restriction
       (widen)
       (pcase command

--- a/phpactor.el
+++ b/phpactor.el
@@ -129,14 +129,6 @@ of GitHub.")
   :group 'phpactor)
 
 ;; Utility functions
-(defun phpactor-find-executable ()
-  "Return Phpactor command or path to executable."
-  (or (when phpactor-executable
-        (php-project--eval-bootstrap-scripts phpactor-executable))
-      (let ((vendor-executable (f-join phpactor-install-directory "vendor/bin/phpactor")))
-        (when (file-exists-p vendor-executable)
-          vendor-executable))
-      (error "Phpactor not found.  Please run phpactor-install-or-update")))
 
 ;;;###autoload
 (defun phpactor-install-or-update ()

--- a/phpactor.el
+++ b/phpactor.el
@@ -74,16 +74,6 @@
   :type 'boolean)
 
 ;; Variables
-;;;###autoload
-(progn
-  (defvar phpactor-executable nil
-    "Path to `phpactor' executable file.")
-  (make-variable-buffer-local 'phpactor-executable)
-  (put 'phpactor-executable 'safe-local-variable
-       #'(lambda (v) (if (consp v)
-                         (and (eq 'root (car v)) (stringp (cdr v)))
-                       (or (null v) (stringp v))))))
-
 (defvar phpactor--debug nil)
 (defvar phpactor-history-size 100)
 (defvar phpactor-history-ring nil)
@@ -121,6 +111,22 @@ of GitHub.")
 
 ;; Special variables
 (defvar phpactor--execute-async nil)
+
+;;;###autoload
+(defun phpactor--find-executable ()
+  (let ((vendor-executable (f-join phpactor-install-directory "vendor/bin/phpactor")))
+    (if (file-exists-p vendor-executable)
+        vendor-executable
+      (warn "Phpactor not found. Please run phpactor-install-or-update")
+      nil)))
+
+ (defcustom phpactor-executable (phpactor--find-executable)
+  "Path to phpactor executable.
+ It is recommemded not to customize this, but if you do, you'll
+ have to ensure a compatible version of phpactor is used."
+  :type '(string)
+  :safe #'stringp
+  :group 'phpactor)
 
 ;; Utility functions
 (defun phpactor-find-executable ()
@@ -154,7 +160,9 @@ of GitHub.")
                                 (php-runtime-quote-string (concat directory file))
                                 (php-runtime-quote-string (concat phpactor-install-directory file)))
              do (php-runtime-expr code))
+    (add-hook 'compilation-finish-functions (lambda (buffer desc) (setq phpactor-executable (phpactor--find-executable))))
     (composer nil "install" "--no-dev")))
+
 (defalias 'phpactor-update #'phpactor-install-or-update)
 
 (defun phpactor-get-working-dir ()
@@ -172,7 +180,7 @@ of GitHub.")
   "Return command string by `SUB-COMMAND' and `ARGS'."
   (declare (indent 1))
   (mapconcat 'shell-quote-argument
-             (cons (phpactor-find-executable)
+             (cons phpactor-executable
                    (cons sub-command args))
              " "))
 
@@ -199,7 +207,6 @@ of GitHub.")
   (let ((json (phpactor--serialize-json (list :action action
                                               :parameters arguments)))
         (output (get-buffer-create "*Phpactor Output*"))
-        (phpactor-executable (phpactor-find-executable))
         (coding-system-for-write 'utf-8)
         (cwd (phpactor-get-working-dir)))
     (with-current-buffer output (erase-buffer))
@@ -543,9 +550,9 @@ function."
 (cl-defun phpactor-action-dispatch (&key action parameters version)
   "Execite action by `NAME' and `PARAMETERS'."
   (when (and version (not (equal phpactor--supported-rpc-version version)))
-    (if (phpactor-find-executable)
+    (if phpactor-executable
         (error "Phpactor uses rpc protocol %s but this package requires %s" version phpactor--supported-rpc-version)
-      (error "Phpactor should be upgraded.  Please run phpactor-update")))
+      (error "Phpactor should be upgraded. Please run phpactor-install-or-update")))
   (phpactor--add-history 'phpactor-action-dispatch (list :action action :parameters parameters :version version))
   (let ((func (cdr-safe (assq (intern action) phpactor-action-table))))
     (if func

--- a/tests/e2e/test-sanity.el
+++ b/tests/e2e/test-sanity.el
@@ -28,8 +28,9 @@
       (with-timeout
           (timeout-duration (display-warning 'buttercup (format "Error : timeout waiting %s seconds for composer install to finish" timeout-duration)))
         (while (not (file-exists-p (f-join phpactor-install-directory "vendor/bin/phpactor")))
-          (sleep-for 1)))
-      (expect (phpactor-find-executable) :to-equal (f-join phpactor-install-directory "vendor/bin/phpactor"))
+          (sleep-for 1))
+        (sleep-for 1))
+      (expect phpactor-executable :to-equal (f-join phpactor-install-directory "vendor/bin/phpactor"))
       )))
 
 (describe "defun: `phpactor-get-working-dir'"


### PR DESCRIPTION
Previous PR #108 got its git history a bit messed so here's a new one.

By doing this, we are able to replace phpactor-find-executable
function which is a bit more optimized as completion makes frequent
use of it.

- update test
- reevaluate phpactor-executable using setq (override defcustom), after
composer install using hook