### PR TITLE
fix path for navigation

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -440,6 +440,8 @@ have to ensure a compatible version of phpactor is used."
   "Open file from Phpactor."
   (unless (and path offset)
     (user-error "Definition not found"))
+  (unless (file-name-absolute-p path)
+    (setq path (expand-file-name path (phpactor-get-working-dir))))
 
   ;; TODO: Implement other target: Phpactor\Extension\Rpc\Response\OpenFileResponse
   ;; `target' expects "focused_window", "vsplit", "hsplit" and "new_tab"


### PR DESCRIPTION
I noticed navigation towards unit test (once setup in .phpactor.yml) would not work because the configured path would be appended to current buffer's file path.

This modification fixes that issue.