### PR TITLE
composer require phpactor/phpactor:~0.13.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr-4": {"EmacsPHP\\Phpactor\\Sample\\": "tests/src/"}
     },
     "require": {
-        "phpactor/phpactor": "^0.12.0"
+        "phpactor/phpactor": "~0.13.2"
     },
     "config": {
         "classmap-authoritative": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65ad5b93ab981ced237cc3ea74fb45ce",
+    "content-hash": "67c7c32f02abad3e846a3ee14a30f2b9",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "dd3f738f1b11ccbc2c6aba8e5240fa5d7a5c3fae"
+                "reference": "f26a67e397be0e5c00d7c52ec7b5010098e15ce5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/dd3f738f1b11ccbc2c6aba8e5240fa5d7a5c3fae",
-                "reference": "dd3f738f1b11ccbc2c6aba8e5240fa5d7a5c3fae",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/f26a67e397be0e5c00d7c52ec7b5010098e15ce5",
+                "reference": "f26a67e397be0e5c00d7c52ec7b5010098e15ce5",
                 "shasum": ""
             },
             "require": {
@@ -60,7 +60,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2019-03-26T10:08:35+00:00"
+            "time": "2019-08-02T09:05:43+00:00"
         },
         {
             "name": "composer/composer",
@@ -68,12 +68,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "88852fbf1adfc1ffeb91e2db7cbbe1aa7f0321f9"
+                "reference": "bfba228b5a232bcb9e4bb7941f0a0aaa37bab117"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/88852fbf1adfc1ffeb91e2db7cbbe1aa7f0321f9",
-                "reference": "88852fbf1adfc1ffeb91e2db7cbbe1aa7f0321f9",
+                "url": "https://api.github.com/repos/composer/composer/zipball/bfba228b5a232bcb9e4bb7941f0a0aaa37bab117",
+                "reference": "bfba228b5a232bcb9e4bb7941f0a0aaa37bab117",
                 "shasum": ""
             },
             "require": {
@@ -140,7 +140,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2019-04-02T09:15:23+00:00"
+            "time": "2019-08-13T15:28:15+00:00"
         },
         {
             "name": "composer/semver",
@@ -148,20 +148,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e"
+                "reference": "37e4db276f38376a63ea67e96b09571d74312779"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
-                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
+                "url": "https://api.github.com/repos/composer/semver/zipball/37e4db276f38376a63ea67e96b09571d74312779",
+                "reference": "37e4db276f38376a63ea67e96b09571d74312779",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5 || ^5.0.5",
-                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+                "phpunit/phpunit": "^4.5 || ^5.0.5"
             },
             "type": "library",
             "extra": {
@@ -202,7 +201,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2019-03-19T17:25:45+00:00"
+            "time": "2019-04-14T09:35:30+00:00"
         },
         {
             "name": "composer/spdx-licenses",
@@ -210,12 +209,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "a1aa51cf3ab838b83b0867b14e56fc20fbd55b3d"
+                "reference": "7ac1e6aec371357df067f8a688c3d6974df68fa5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/a1aa51cf3ab838b83b0867b14e56fc20fbd55b3d",
-                "reference": "a1aa51cf3ab838b83b0867b14e56fc20fbd55b3d",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/7ac1e6aec371357df067f8a688c3d6974df68fa5",
+                "reference": "7ac1e6aec371357df067f8a688c3d6974df68fa5",
                 "shasum": ""
             },
             "require": {
@@ -262,20 +261,20 @@
                 "spdx",
                 "validator"
             ],
-            "time": "2019-03-26T10:23:26+00:00"
+            "time": "2019-07-29T10:31:59+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "d17708133b6c276d6e42ef887a877866b909d892"
+                "reference": "46867cbf8ca9fb8d60c506895449eb799db1184f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/d17708133b6c276d6e42ef887a877866b909d892",
-                "reference": "d17708133b6c276d6e42ef887a877866b909d892",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/46867cbf8ca9fb8d60c506895449eb799db1184f",
+                "reference": "46867cbf8ca9fb8d60c506895449eb799db1184f",
                 "shasum": ""
             },
             "require": {
@@ -306,7 +305,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2019-01-28T20:25:53+00:00"
+            "time": "2019-05-27T17:52:04+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -347,12 +346,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "9abc39791684db13f3239454b050b97c2ffe7982"
+                "reference": "3f4e4949dc39aa8e28d5565366a24fea47116bc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/9abc39791684db13f3239454b050b97c2ffe7982",
-                "reference": "9abc39791684db13f3239454b050b97c2ffe7982",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/3f4e4949dc39aa8e28d5565366a24fea47116bc7",
+                "reference": "3f4e4949dc39aa8e28d5565366a24fea47116bc7",
                 "shasum": ""
             },
             "require-dev": {
@@ -362,6 +361,11 @@
                 "phpunit/phpunit": "7.1.4"
             },
             "type": "library",
+            "autoload": {
+                "files": [
+                    "PhpStormStubsMap.php"
+                ]
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "Apache-2.0"
@@ -378,7 +382,7 @@
                 "stubs",
                 "type"
             ],
-            "time": "2019-04-02T14:55:00+00:00"
+            "time": "2019-08-28T15:48:22+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -448,16 +452,16 @@
         },
         {
             "name": "microsoft/tolerant-php-parser",
-            "version": "v0.0.17",
+            "version": "v0.0.18",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Microsoft/tolerant-php-parser.git",
-                "reference": "89386de8dec9c004c8ea832692e236c92f34b542"
+                "url": "https://github.com/microsoft/tolerant-php-parser.git",
+                "reference": "e255aa978b45729094da2a1a6f9954044a244ff2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Microsoft/tolerant-php-parser/zipball/89386de8dec9c004c8ea832692e236c92f34b542",
-                "reference": "89386de8dec9c004c8ea832692e236c92f34b542",
+                "url": "https://api.github.com/repos/microsoft/tolerant-php-parser/zipball/e255aa978b45729094da2a1a6f9954044a244ff2",
+                "reference": "e255aa978b45729094da2a1a6f9954044a244ff2",
                 "shasum": ""
             },
             "require": {
@@ -485,7 +489,7 @@
                 }
             ],
             "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
-            "time": "2019-03-09T19:24:59+00:00"
+            "time": "2019-07-01T02:21:00+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -493,12 +497,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "4d5b7e6ba1127789c7ff59d6f762298eaa29787f"
+                "reference": "1b5341b08b1e54db0a3b6449683465d1d5bc4db8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/4d5b7e6ba1127789c7ff59d6f762298eaa29787f",
-                "reference": "4d5b7e6ba1127789c7ff59d6f762298eaa29787f",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1b5341b08b1e54db0a3b6449683465d1d5bc4db8",
+                "reference": "1b5341b08b1e54db0a3b6449683465d1d5bc4db8",
                 "shasum": ""
             },
             "require": {
@@ -563,7 +567,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2018-12-26T14:24:03+00:00"
+            "time": "2019-08-16T10:54:42+00:00"
         },
         {
             "name": "ocramius/package-versions",
@@ -621,30 +625,31 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/class-mover.git",
-                "reference": "8c87bd29d2b4ddbf3239dbabe6d42883d1e61fff"
+                "reference": "7828b0770385714a181508198d154bbee172069c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/class-mover/zipball/8c87bd29d2b4ddbf3239dbabe6d42883d1e61fff",
-                "reference": "8c87bd29d2b4ddbf3239dbabe6d42883d1e61fff",
+                "url": "https://api.github.com/repos/phpactor/class-mover/zipball/7828b0770385714a181508198d154bbee172069c",
+                "reference": "7828b0770385714a181508198d154bbee172069c",
                 "shasum": ""
             },
             "require": {
                 "microsoft/tolerant-php-parser": "@dev",
                 "php": "^7.1",
-                "psr/log": "^1.0@dev",
+                "psr/log": "~1.0",
                 "symfony/filesystem": "^2.7|^3.0"
             },
             "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "phpactor/worse-reflection": "~0.1",
-                "phpstan/phpstan": "^0.8.1",
-                "phpunit/phpunit": "^6.2",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0",
                 "symfony/console": "^3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.1.x-dev"
+                    "dev-master": "0.2.x-dev"
                 }
             },
             "autoload": {
@@ -663,7 +668,7 @@
                 }
             ],
             "description": "Library for moving classes",
-            "time": "2019-01-06T11:48:33+00:00"
+            "time": "2019-08-24T14:03:40+00:00"
         },
         {
             "name": "phpactor/class-to-file",
@@ -671,12 +676,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/class-to-file.git",
-                "reference": "524af90cef3ba6e30f07994ea8c0a89ab48b39e4"
+                "reference": "a47ba11a26264d0b5b6603ebca73c66cd351550e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/class-to-file/zipball/524af90cef3ba6e30f07994ea8c0a89ab48b39e4",
-                "reference": "524af90cef3ba6e30f07994ea8c0a89ab48b39e4",
+                "url": "https://api.github.com/repos/phpactor/class-to-file/zipball/a47ba11a26264d0b5b6603ebca73c66cd351550e",
+                "reference": "a47ba11a26264d0b5b6603ebca73c66cd351550e",
                 "shasum": ""
             },
             "require": {
@@ -684,13 +689,15 @@
                 "webmozart/path-util": "^2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0",
                 "symfony/filesystem": "^3.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.3.x-dev"
+                    "dev-master": "0.4.x-dev"
                 }
             },
             "autoload": {
@@ -709,20 +716,20 @@
                 }
             ],
             "description": "Library to covert class names to file paths and vice-versa",
-            "time": "2019-01-17T07:26:00+00:00"
+            "time": "2019-08-24T14:03:40+00:00"
         },
         {
             "name": "phpactor/class-to-file-extension",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/class-to-file-extension.git",
-                "reference": "5f16157f5258c25cccd6de64ddcadc4c43e543dd"
+                "reference": "f7bc66301f996f316386eccda642874e3a4d424e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/class-to-file-extension/zipball/5f16157f5258c25cccd6de64ddcadc4c43e543dd",
-                "reference": "5f16157f5258c25cccd6de64ddcadc4c43e543dd",
+                "url": "https://api.github.com/repos/phpactor/class-to-file-extension/zipball/f7bc66301f996f316386eccda642874e3a4d424e",
+                "reference": "f7bc66301f996f316386eccda642874e3a4d424e",
                 "shasum": ""
             },
             "require": {
@@ -731,15 +738,15 @@
                 "phpactor/container": "^1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
                 "phpactor.extension_class": "Phpactor\\Extension\\ClassToFile\\ClassToFileExtension",
                 "branch-alias": {
-                    "dev-master": "0.3.x-dev"
+                    "dev-master": "0.1.x-dev"
                 }
             },
             "autoload": {
@@ -758,7 +765,7 @@
                 }
             ],
             "description": "Converts classes to files and vice-versa",
-            "time": "2019-03-03T11:42:23+00:00"
+            "time": "2019-08-24T11:33:25+00:00"
         },
         {
             "name": "phpactor/code-builder",
@@ -766,12 +773,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/code-builder.git",
-                "reference": "1859c4fa8b673565c1f9bf3028dc06221f35a9a8"
+                "reference": "a530ce1710ab745130fdc504cc0e7d0dd341fc35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/code-builder/zipball/1859c4fa8b673565c1f9bf3028dc06221f35a9a8",
-                "reference": "1859c4fa8b673565c1f9bf3028dc06221f35a9a8",
+                "url": "https://api.github.com/repos/phpactor/code-builder/zipball/a530ce1710ab745130fdc504cc0e7d0dd341fc35",
+                "reference": "a530ce1710ab745130fdc504cc0e7d0dd341fc35",
                 "shasum": ""
             },
             "require": {
@@ -781,8 +788,10 @@
                 "twig/twig": "^2.4"
             },
             "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "phpactor/test-utils": "^1.0",
-                "phpunit/phpunit": "^6.2"
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "library",
             "extra": {
@@ -806,7 +815,7 @@
                 }
             ],
             "description": "Generating and modifying source code",
-            "time": "2019-03-03T12:16:50+00:00"
+            "time": "2019-08-24T14:03:40+00:00"
         },
         {
             "name": "phpactor/code-transform",
@@ -814,30 +823,30 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/code-transform.git",
-                "reference": "c75b56e12cbc56a9d0cd0b8c172a8dd6020e78ad"
+                "reference": "62e48d83b17c8150af59996299652f300a958490"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/code-transform/zipball/c75b56e12cbc56a9d0cd0b8c172a8dd6020e78ad",
-                "reference": "c75b56e12cbc56a9d0cd0b8c172a8dd6020e78ad",
+                "url": "https://api.github.com/repos/phpactor/code-transform/zipball/62e48d83b17c8150af59996299652f300a958490",
+                "reference": "62e48d83b17c8150af59996299652f300a958490",
                 "shasum": ""
             },
             "require": {
                 "phpactor/class-to-file": "~0.3",
-                "phpactor/code-builder": "~0.2",
+                "phpactor/code-builder": "~0.3",
                 "webmozart/path-util": "~2.3"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "phpactor/test-utils": "^1.0@dev",
                 "phpactor/worse-reflection": "~0.1",
-                "phpstan/phpstan": "^0.10.3",
-                "phpunit/phpunit": "^7.3"
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.1.x-dev"
+                    "dev-master": "0.2.x-dev"
                 }
             },
             "autoload": {
@@ -856,7 +865,7 @@
                 }
             ],
             "description": "Applies introspective transformations on source code",
-            "time": "2019-02-03T19:02:29+00:00"
+            "time": "2019-08-24T14:03:40+00:00"
         },
         {
             "name": "phpactor/code-transform-extension",
@@ -864,12 +873,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/code-transform-extension.git",
-                "reference": "22396c1067ce22e7eb6be92e868df27df820140a"
+                "reference": "469d63b974b200449cc9bebb61e35eb473d2959a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/code-transform-extension/zipball/22396c1067ce22e7eb6be92e868df27df820140a",
-                "reference": "22396c1067ce22e7eb6be92e868df27df820140a",
+                "url": "https://api.github.com/repos/phpactor/code-transform-extension/zipball/469d63b974b200449cc9bebb61e35eb473d2959a",
+                "reference": "469d63b974b200449cc9bebb61e35eb473d2959a",
                 "shasum": ""
             },
             "require": {
@@ -878,11 +887,11 @@
                 "phpactor/container": "^1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "phpactor/rpc-extension": "^0.1.0@dev",
                 "phpactor/test-utils": "^1.0@dev",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4"
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
@@ -907,7 +916,7 @@
                 }
             ],
             "description": "Code transform base package",
-            "time": "2019-01-27T10:33:16+00:00"
+            "time": "2019-08-24T14:03:40+00:00"
         },
         {
             "name": "phpactor/completion",
@@ -915,12 +924,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion.git",
-                "reference": "3410fb81f89fd680027b6349d110f11735ec1467"
+                "reference": "89f22b6161797605161783ceea68fea8d71718c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/completion/zipball/3410fb81f89fd680027b6349d110f11735ec1467",
-                "reference": "3410fb81f89fd680027b6349d110f11735ec1467",
+                "url": "https://api.github.com/repos/phpactor/completion/zipball/89f22b6161797605161783ceea68fea8d71718c9",
+                "reference": "89f22b6161797605161783ceea68fea8d71718c9",
                 "shasum": ""
             },
             "require": {
@@ -931,11 +940,11 @@
                 "phpactor/worse-reflection": "~0.2"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "phpactor/test-utils": "^1.0@dev",
                 "phpbench/phpbench": "^1.0@dev",
-                "phpstan/phpstan": "0.10.3",
-                "phpunit/phpunit": "^7.0"
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "library",
             "extra": {
@@ -959,7 +968,7 @@
                 }
             ],
             "description": "Completion library for Worse Reflection",
-            "time": "2019-03-24T09:44:23+00:00"
+            "time": "2019-08-24T18:58:10+00:00"
         },
         {
             "name": "phpactor/completion-extension",
@@ -967,12 +976,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion-extension.git",
-                "reference": "bdd9ef76813acf4ae6a81bc2f1d55b4e04c33020"
+                "reference": "b4b92a83e0da521f161c23b300ac2d508858d835"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/completion-extension/zipball/bdd9ef76813acf4ae6a81bc2f1d55b4e04c33020",
-                "reference": "bdd9ef76813acf4ae6a81bc2f1d55b4e04c33020",
+                "url": "https://api.github.com/repos/phpactor/completion-extension/zipball/b4b92a83e0da521f161c23b300ac2d508858d835",
+                "reference": "b4b92a83e0da521f161c23b300ac2d508858d835",
                 "shasum": ""
             },
             "require": {
@@ -981,9 +990,9 @@
                 "phpactor/logging-extension": "~0.1"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
-                "phpstan/phpstan": "^0.10.4",
-                "phpunit/phpunit": "^7.4"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
@@ -1008,7 +1017,7 @@
                 }
             ],
             "description": "Phpactor Code Completion Extension",
-            "time": "2019-01-12T16:49:41+00:00"
+            "time": "2019-08-24T14:03:41+00:00"
         },
         {
             "name": "phpactor/completion-rpc-extension",
@@ -1016,12 +1025,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion-rpc-extension.git",
-                "reference": "0968cd63d4408905e4a4df646986de5a6822343e"
+                "reference": "acdd65a48acb4067a22ad2041be83a49a5aa8cd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/completion-rpc-extension/zipball/0968cd63d4408905e4a4df646986de5a6822343e",
-                "reference": "0968cd63d4408905e4a4df646986de5a6822343e",
+                "url": "https://api.github.com/repos/phpactor/completion-rpc-extension/zipball/acdd65a48acb4067a22ad2041be83a49a5aa8cd2",
+                "reference": "acdd65a48acb4067a22ad2041be83a49a5aa8cd2",
                 "shasum": ""
             },
             "require": {
@@ -1029,10 +1038,10 @@
                 "phpactor/rpc-extension": "~0.1"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "phpactor/test-utils": "^1.0",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4"
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
@@ -1057,20 +1066,20 @@
                 }
             ],
             "description": "RPC support for the Completion Extension",
-            "time": "2019-01-06T11:32:15+00:00"
+            "time": "2019-08-24T14:03:41+00:00"
         },
         {
             "name": "phpactor/completion-worse-extension",
-            "version": "0.1.1",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion-worse-extension.git",
-                "reference": "3d1b510b7af4573b453d13d912236b3fdefcc7f5"
+                "reference": "5172c76daaf9137b5fa44ae2b1ced89f50d989f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/completion-worse-extension/zipball/3d1b510b7af4573b453d13d912236b3fdefcc7f5",
-                "reference": "3d1b510b7af4573b453d13d912236b3fdefcc7f5",
+                "url": "https://api.github.com/repos/phpactor/completion-worse-extension/zipball/5172c76daaf9137b5fa44ae2b1ced89f50d989f5",
+                "reference": "5172c76daaf9137b5fa44ae2b1ced89f50d989f5",
                 "shasum": ""
             },
             "require": {
@@ -1079,9 +1088,9 @@
                 "phpactor/worse-reflection-extension": "~0.2"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
-                "phpstan/phpstan": "^0.10.4",
-                "phpunit/phpunit": "^7.4"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
@@ -1106,20 +1115,20 @@
                 }
             ],
             "description": "Collection of completors based on Worse Reflection and the Tolerant PHP Parser",
-            "time": "2019-01-12T17:07:59+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpactor/composer-autoloader-extension",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/composer-autoloader-extension.git",
-                "reference": "836f4e98ace65a25acd178ef596842bd26999c56"
+                "reference": "6ef27b06a49f39db92380833d24d7f92eca363b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/composer-autoloader-extension/zipball/836f4e98ace65a25acd178ef596842bd26999c56",
-                "reference": "836f4e98ace65a25acd178ef596842bd26999c56",
+                "url": "https://api.github.com/repos/phpactor/composer-autoloader-extension/zipball/6ef27b06a49f39db92380833d24d7f92eca363b6",
+                "reference": "6ef27b06a49f39db92380833d24d7f92eca363b6",
                 "shasum": ""
             },
             "require": {
@@ -1128,15 +1137,15 @@
                 "phpactor/logging-extension": "~0.2"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
                 "phpactor.extension_class": "Phpactor\\Extension\\ComposerAutoloader\\ComposerAutoloaderExtension",
                 "branch-alias": {
-                    "dev-master": "0.2.x-dev"
+                    "dev-master": "0.1.x-dev"
                 }
             },
             "autoload": {
@@ -1155,20 +1164,20 @@
                 }
             ],
             "description": "Composer Autoloader provider",
-            "time": "2019-03-03T12:05:19+00:00"
+            "time": "2019-08-24T11:33:25+00:00"
         },
         {
             "name": "phpactor/config-loader",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/config-loader.git",
-                "reference": "ad0ed03d2a72bd6c3d5aeb1740dc07791c7e3093"
+                "reference": "61db28afa005ac814d7cf48fce70f07e897e038c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/config-loader/zipball/ad0ed03d2a72bd6c3d5aeb1740dc07791c7e3093",
-                "reference": "ad0ed03d2a72bd6c3d5aeb1740dc07791c7e3093",
+                "url": "https://api.github.com/repos/phpactor/config-loader/zipball/61db28afa005ac814d7cf48fce70f07e897e038c",
+                "reference": "61db28afa005ac814d7cf48fce70f07e897e038c",
                 "shasum": ""
             },
             "require": {
@@ -1176,17 +1185,17 @@
                 "webmozart/path-util": "^2.3"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "phpactor/test-utils": "^1.0",
                 "phpbench/phpbench": "^0.14.0",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0",
                 "symfony/yaml": "^4.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -1205,7 +1214,7 @@
                 }
             ],
             "description": "Library to load (user) configuration",
-            "time": "2019-02-16T15:35:49+00:00"
+            "time": "2019-08-24T11:33:25+00:00"
         },
         {
             "name": "phpactor/console-extension",
@@ -1213,12 +1222,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/console-extension.git",
-                "reference": "4f7b24005629307ebeb2adae1ae69124560a3b41"
+                "reference": "58925791b75fea9d113495d16418446d7d8942fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/console-extension/zipball/4f7b24005629307ebeb2adae1ae69124560a3b41",
-                "reference": "4f7b24005629307ebeb2adae1ae69124560a3b41",
+                "url": "https://api.github.com/repos/phpactor/console-extension/zipball/58925791b75fea9d113495d16418446d7d8942fc",
+                "reference": "58925791b75fea9d113495d16418446d7d8942fc",
                 "shasum": ""
             },
             "require": {
@@ -1226,9 +1235,9 @@
                 "symfony/console": "^4.1"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
@@ -1253,20 +1262,20 @@
                 }
             ],
             "description": "Integrate Symfony Console commands",
-            "time": "2019-01-06T11:53:30+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpactor/container",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/container.git",
-                "reference": "dbeba5667f6530be03bec2ade148764ea006b085"
+                "reference": "8e012ee6045ed72f4cf417bf7dc2d9d7ec457d5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/container/zipball/dbeba5667f6530be03bec2ade148764ea006b085",
-                "reference": "dbeba5667f6530be03bec2ade148764ea006b085",
+                "url": "https://api.github.com/repos/phpactor/container/zipball/8e012ee6045ed72f4cf417bf7dc2d9d7ec457d5f",
+                "reference": "8e012ee6045ed72f4cf417bf7dc2d9d7ec457d5f",
                 "shasum": ""
             },
             "require": {
@@ -1274,7 +1283,9 @@
                 "psr/container": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.3"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "library",
             "autoload": {
@@ -1293,7 +1304,7 @@
                 }
             ],
             "description": "Phpactor's DI Container",
-            "time": "2019-01-01T22:44:29+00:00"
+            "time": "2019-08-24T11:33:25+00:00"
         },
         {
             "name": "phpactor/docblock",
@@ -1301,16 +1312,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/docblock.git",
-                "reference": "0acb9bf8d6b4cd5ee5cb4111d8aa347138484343"
+                "reference": "3e95c6e46f639ed55a5d3bcfdb349767e47a9512"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/docblock/zipball/0acb9bf8d6b4cd5ee5cb4111d8aa347138484343",
-                "reference": "0acb9bf8d6b4cd5ee5cb4111d8aa347138484343",
+                "url": "https://api.github.com/repos/phpactor/docblock/zipball/3e95c6e46f639ed55a5d3bcfdb349767e47a9512",
+                "reference": "3e95c6e46f639ed55a5d3bcfdb349767e47a9512",
                 "shasum": ""
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.5"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "library",
             "extra": {
@@ -1334,7 +1347,7 @@
                 }
             ],
             "description": "Simple Docblock Parser",
-            "time": "2019-03-03T12:35:29+00:00"
+            "time": "2019-08-28T08:15:06+00:00"
         },
         {
             "name": "phpactor/extension-manager-extension",
@@ -1342,12 +1355,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/extension-manager-extension.git",
-                "reference": "7bf6951ebe1f53699ecb5887708e9dcf02240070"
+                "reference": "4af13b2438fc722f56ade5a2c1bf91980943e0ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/extension-manager-extension/zipball/7bf6951ebe1f53699ecb5887708e9dcf02240070",
-                "reference": "7bf6951ebe1f53699ecb5887708e9dcf02240070",
+                "url": "https://api.github.com/repos/phpactor/extension-manager-extension/zipball/4af13b2438fc722f56ade5a2c1bf91980943e0ee",
+                "reference": "4af13b2438fc722f56ade5a2c1bf91980943e0ee",
                 "shasum": ""
             },
             "require": {
@@ -1358,11 +1371,11 @@
                 "webmozart/path-util": "^2.3"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "phpactor/rpc-extension": "~0.1",
                 "phpactor/test-utils": "^1.0",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4"
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
@@ -1387,20 +1400,20 @@
                 }
             ],
             "description": "Install, remove and otherwise manage extensions",
-            "time": "2019-03-17T11:02:48+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpactor/file-path-resolver",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/file-path-resolver.git",
-                "reference": "01ab55ab723adb72859bdfd57db02013a739e370"
+                "reference": "74ace7bac0c4fc1a80001152bcc5c66d3d990acb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/file-path-resolver/zipball/01ab55ab723adb72859bdfd57db02013a739e370",
-                "reference": "01ab55ab723adb72859bdfd57db02013a739e370",
+                "url": "https://api.github.com/repos/phpactor/file-path-resolver/zipball/74ace7bac0c4fc1a80001152bcc5c66d3d990acb",
+                "reference": "74ace7bac0c4fc1a80001152bcc5c66d3d990acb",
                 "shasum": ""
             },
             "require": {
@@ -1408,10 +1421,10 @@
                 "webmozart/path-util": "^2.3"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "phpbench/phpbench": "^0.14.0",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0",
                 "psr/log": "^1.1"
             },
             "type": "library",
@@ -1431,7 +1444,7 @@
                 }
             ],
             "description": "Resolve files paths for your application (e.g. cache, data, etc)",
-            "time": "2019-01-01T15:50:20+00:00"
+            "time": "2019-08-24T11:33:25+00:00"
         },
         {
             "name": "phpactor/file-path-resolver-extension",
@@ -1439,12 +1452,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/file-path-resolver-extension.git",
-                "reference": "8a3230a56d14bbe1cf6e0348c5ab4d7a7cc1d0ca"
+                "reference": "b56095dbeb61d662f22e954572eb1033e9c57cf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/file-path-resolver-extension/zipball/8a3230a56d14bbe1cf6e0348c5ab4d7a7cc1d0ca",
-                "reference": "8a3230a56d14bbe1cf6e0348c5ab4d7a7cc1d0ca",
+                "url": "https://api.github.com/repos/phpactor/file-path-resolver-extension/zipball/b56095dbeb61d662f22e954572eb1033e9c57cf5",
+                "reference": "b56095dbeb61d662f22e954572eb1033e9c57cf5",
                 "shasum": ""
             },
             "require": {
@@ -1453,9 +1466,9 @@
                 "phpactor/logging-extension": "~0.3"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
@@ -1480,20 +1493,20 @@
                 }
             ],
             "description": "File Path Resolver Extension",
-            "time": "2019-01-01T15:55:12+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpactor/logging-extension",
-            "version": "0.3.0",
+            "version": "0.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/logging-extension.git",
-                "reference": "df7c25c0acd13cc8156b56c5d950ce04de79b566"
+                "reference": "306149d2ab1582ff389a71fce45d270f5f7c9ac1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/logging-extension/zipball/df7c25c0acd13cc8156b56c5d950ce04de79b566",
-                "reference": "df7c25c0acd13cc8156b56c5d950ce04de79b566",
+                "url": "https://api.github.com/repos/phpactor/logging-extension/zipball/306149d2ab1582ff389a71fce45d270f5f7c9ac1",
+                "reference": "306149d2ab1582ff389a71fce45d270f5f7c9ac1",
                 "shasum": ""
             },
             "require": {
@@ -1501,9 +1514,9 @@
                 "phpactor/container": "^1.1"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
@@ -1525,24 +1538,26 @@
                 }
             ],
             "description": "PSR logging extension",
-            "time": "2018-11-11T15:20:35+00:00"
+            "time": "2019-08-24T11:33:25+00:00"
         },
         {
             "name": "phpactor/map-resolver",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/map-resolver.git",
-                "reference": "99cab3dcec9ada1010d972682701df81e061bb2e"
+                "reference": "6c467a07ed715bc0fd59cfc232e4996b5593562e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/map-resolver/zipball/99cab3dcec9ada1010d972682701df81e061bb2e",
-                "reference": "99cab3dcec9ada1010d972682701df81e061bb2e",
+                "url": "https://api.github.com/repos/phpactor/map-resolver/zipball/6c467a07ed715bc0fd59cfc232e4996b5593562e",
+                "reference": "6c467a07ed715bc0fd59cfc232e4996b5593562e",
                 "shasum": ""
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.3"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "library",
             "autoload": {
@@ -1561,28 +1576,29 @@
                 }
             ],
             "description": "Map Resolver",
-            "time": "2018-10-26T13:29:57+00:00"
+            "time": "2019-08-24T11:33:25+00:00"
         },
         {
             "name": "phpactor/path-finder",
-            "version": "dev-master",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/path-finder.git",
-                "reference": "9375374c41bf4e0b290a2e2e46bd0d341944d2c0"
+                "reference": "14f4c7a658ea501e7679d27bbf5d2abec1a9ad07"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/path-finder/zipball/9375374c41bf4e0b290a2e2e46bd0d341944d2c0",
-                "reference": "9375374c41bf4e0b290a2e2e46bd0d341944d2c0",
+                "url": "https://api.github.com/repos/phpactor/path-finder/zipball/14f4c7a658ea501e7679d27bbf5d2abec1a9ad07",
+                "reference": "14f4c7a658ea501e7679d27bbf5d2abec1a9ad07",
                 "shasum": ""
             },
             "require": {
                 "webmozart/path-util": "^2.3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.8.5",
-                "phpunit/phpunit": "^6.1"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "library",
             "extra": {
@@ -1606,20 +1622,20 @@
                 }
             ],
             "description": "Utility for navigating to related source files",
-            "time": "2017-11-04T12:57:48+00:00"
+            "time": "2019-08-24T11:33:25+00:00"
         },
         {
             "name": "phpactor/phpactor",
-            "version": "0.12.0.x-dev",
+            "version": "0.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/phpactor.git",
-                "reference": "b37de8b69d525ce8e0d5a30decd59017d656df51"
+                "reference": "81238171ca025ec24fe0c21ec7ac761c83a274fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/phpactor/zipball/b37de8b69d525ce8e0d5a30decd59017d656df51",
-                "reference": "b37de8b69d525ce8e0d5a30decd59017d656df51",
+                "url": "https://api.github.com/repos/phpactor/phpactor/zipball/81238171ca025ec24fe0c21ec7ac761c83a274fd",
+                "reference": "81238171ca025ec24fe0c21ec7ac761c83a274fd",
                 "shasum": ""
             },
             "require": {
@@ -1628,30 +1644,34 @@
                 "ocramius/package-versions": "^1.2",
                 "php": "^7.1",
                 "phpactor/class-mover": "~0.1",
+                "phpactor/class-to-file": "~0.3",
                 "phpactor/class-to-file-extension": "~0.2",
-                "phpactor/code-transform": "~0.1",
-                "phpactor/code-transform-extension": "^0.1",
-                "phpactor/completion": "~0.2",
+                "phpactor/code-builder": "~0.3",
+                "phpactor/code-transform": "~0.2",
+                "phpactor/code-transform-extension": "~0.1",
+                "phpactor/completion": "~0.3",
                 "phpactor/completion-extension": "~0.2",
                 "phpactor/completion-rpc-extension": "~0.2",
-                "phpactor/completion-worse-extension": "~0.1.1",
-                "phpactor/composer-autoloader-extension": "~0.1",
+                "phpactor/completion-worse-extension": "~0.1",
+                "phpactor/composer-autoloader-extension": "~0.2",
                 "phpactor/config-loader": "~0.1",
                 "phpactor/console-extension": "~0.1",
-                "phpactor/container": "^1.0",
-                "phpactor/extension-manager-extension": "~0.1",
-                "phpactor/file-path-resolver-extension": "~0.1",
+                "phpactor/container": "~1.3",
+                "phpactor/docblock": "~0.3",
+                "phpactor/extension-manager-extension": "~0.8",
+                "phpactor/file-path-resolver-extension": "~0.3",
                 "phpactor/logging-extension": "~0.2",
-                "phpactor/path-finder": "dev-master",
+                "phpactor/path-finder": "~0.1",
                 "phpactor/reference-finder-rpc-extension": "~0.1",
-                "phpactor/rpc-extension": "~0.1",
+                "phpactor/rpc-extension": "~0.2",
                 "phpactor/source-code-filesystem": "~0.1",
-                "phpactor/source-code-filesystem-extension": "~0.1.2",
+                "phpactor/source-code-filesystem-extension": "~0.1",
+                "phpactor/text-document": "~1.1",
                 "phpactor/worse-reference-finder-extension": "~0.1",
-                "phpactor/worse-reflection": "~0.1",
-                "phpactor/worse-reflection-extension": "~0.1",
+                "phpactor/worse-reflection": "~0.3",
+                "phpactor/worse-reflection-extension": "~0.2",
                 "phpbench/container": "^1.0",
-                "sebastian/diff": "2.0.x-dev",
+                "sebastian/diff": "^3.0",
                 "symfony/filesystem": "^3.3",
                 "symfony/yaml": "^3.3",
                 "webmozart/glob": "^4.1"
@@ -1661,7 +1681,7 @@
                 "friendsofphp/php-cs-fixer": "^2.12@dev",
                 "phpactor/test-utils": "dev-master",
                 "phpbench/phpbench": "^1.0@dev",
-                "phpunit/phpunit": "^6.0",
+                "phpunit/phpunit": "^7.0",
                 "symfony/debug": "^4.0",
                 "symfony/options-resolver": "^2.7|^3.0",
                 "symfony/process": "^2.7|^3.0"
@@ -1676,8 +1696,11 @@
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
             "description": "PHP refactoring and intellisense tool for text editors",
-            "time": "2019-03-03T14:44:33+00:00"
+            "time": "2019-08-25T21:35:21+00:00"
         },
         {
             "name": "phpactor/reference-finder",
@@ -1685,12 +1708,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/reference-finder.git",
-                "reference": "4b47b71607e882d43d39c8093bb4f3470ce02a43"
+                "reference": "abb27863bbe26b1cf227dce5d3c36d9917c2275f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/reference-finder/zipball/4b47b71607e882d43d39c8093bb4f3470ce02a43",
-                "reference": "4b47b71607e882d43d39c8093bb4f3470ce02a43",
+                "url": "https://api.github.com/repos/phpactor/reference-finder/zipball/abb27863bbe26b1cf227dce5d3c36d9917c2275f",
+                "reference": "abb27863bbe26b1cf227dce5d3c36d9917c2275f",
                 "shasum": ""
             },
             "require": {
@@ -1699,9 +1722,9 @@
                 "webmozart/path-util": "^2.3"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "library",
             "extra": {
@@ -1725,7 +1748,7 @@
                 }
             ],
             "description": "Base library for finding definitions",
-            "time": "2019-03-03T12:25:39+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpactor/reference-finder-extension",
@@ -1733,12 +1756,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/reference-finder-extension.git",
-                "reference": "ea043ba814f9a8168e5f017957c42b1d6e747a35"
+                "reference": "6b6bbca0533f9d161e26feec8c5b2794fcb56a1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/reference-finder-extension/zipball/ea043ba814f9a8168e5f017957c42b1d6e747a35",
-                "reference": "ea043ba814f9a8168e5f017957c42b1d6e747a35",
+                "url": "https://api.github.com/repos/phpactor/reference-finder-extension/zipball/6b6bbca0533f9d161e26feec8c5b2794fcb56a1a",
+                "reference": "6b6bbca0533f9d161e26feec8c5b2794fcb56a1a",
                 "shasum": ""
             },
             "require": {
@@ -1747,9 +1770,9 @@
                 "phpactor/reference-finder": "~0.1"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
-                "phpstan/phpstan": "^0.10.6",
-                "phpunit/phpunit": "^7.5"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
@@ -1774,7 +1797,7 @@
                 }
             ],
             "description": "Goto definition functionality",
-            "time": "2019-03-03T12:22:08+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpactor/reference-finder-rpc-extension",
@@ -1782,29 +1805,29 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/reference-finder-rpc-extension.git",
-                "reference": "0958459b72794b45d20d79bf0d78c4c82b6f6ade"
+                "reference": "61521d2a9291719e53f2caab735d51524a9b4a37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/reference-finder-rpc-extension/zipball/0958459b72794b45d20d79bf0d78c4c82b6f6ade",
-                "reference": "0958459b72794b45d20d79bf0d78c4c82b6f6ade",
+                "url": "https://api.github.com/repos/phpactor/reference-finder-rpc-extension/zipball/61521d2a9291719e53f2caab735d51524a9b4a37",
+                "reference": "61521d2a9291719e53f2caab735d51524a9b4a37",
                 "shasum": ""
             },
             "require": {
                 "phpactor/container": "^1.0",
                 "phpactor/reference-finder-extension": "~0.1",
-                "phpactor/rpc-extension": "~0.1"
+                "phpactor/rpc-extension": "~0.2"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
-                "phpstan/phpstan": "^0.10.6",
-                "phpunit/phpunit": "^7.5"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
                 "phpactor.extension_class": "Phpactor\\Extension\\ReferenceFinderRpc\\ReferenceFinderRpcExtension",
                 "branch-alias": {
-                    "dev-master": "0.1.x-dev"
+                    "dev-master": "0.2.x-dev"
                 }
             },
             "autoload": {
@@ -1823,7 +1846,7 @@
                 }
             ],
             "description": "Description about my project",
-            "time": "2019-01-06T12:13:56+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpactor/rpc-extension",
@@ -1831,12 +1854,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/rpc-extension.git",
-                "reference": "520431256783babac3f23f27d73dd19d824accfb"
+                "reference": "2997da8601ea04b278517052b116dc018d390f25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/rpc-extension/zipball/520431256783babac3f23f27d73dd19d824accfb",
-                "reference": "520431256783babac3f23f27d73dd19d824accfb",
+                "url": "https://api.github.com/repos/phpactor/rpc-extension/zipball/2997da8601ea04b278517052b116dc018d390f25",
+                "reference": "2997da8601ea04b278517052b116dc018d390f25",
                 "shasum": ""
             },
             "require": {
@@ -1846,10 +1869,10 @@
                 "phpactor/logging-extension": "~0.2"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "phpactor/test-utils": "^1.0",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4"
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
@@ -1874,7 +1897,7 @@
                 }
             ],
             "description": "RPC Extension",
-            "time": "2019-03-03T12:28:28+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpactor/source-code-filesystem",
@@ -1882,20 +1905,21 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/source-code-filesystem.git",
-                "reference": "9f223092c35b65c86536ccc762741b32ea215549"
+                "reference": "7b4fbc2a4229e497554aa1c4c6c545ff2891cf79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/source-code-filesystem/zipball/9f223092c35b65c86536ccc762741b32ea215549",
-                "reference": "9f223092c35b65c86536ccc762741b32ea215549",
+                "url": "https://api.github.com/repos/phpactor/source-code-filesystem/zipball/7b4fbc2a4229e497554aa1c4c6c545ff2891cf79",
+                "reference": "7b4fbc2a4229e497554aa1c4c6c545ff2891cf79",
                 "shasum": ""
             },
             "require": {
                 "webmozart/path-util": "^2.3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.9.2",
-                "phpunit/phpunit": "^6.2",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0",
                 "symfony/filesystem": "^3.3"
             },
             "type": "library",
@@ -1920,7 +1944,7 @@
                 }
             ],
             "description": "Filesystem library for working with source code files",
-            "time": "2019-01-06T11:59:25+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpactor/source-code-filesystem-extension",
@@ -1928,12 +1952,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/source-code-filesystem-extension.git",
-                "reference": "9650971e3017f908e04db88157d3927915170f28"
+                "reference": "950356de7040f0ee89f32916b6bb58e3c071dfae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/source-code-filesystem-extension/zipball/9650971e3017f908e04db88157d3927915170f28",
-                "reference": "9650971e3017f908e04db88157d3927915170f28",
+                "url": "https://api.github.com/repos/phpactor/source-code-filesystem-extension/zipball/950356de7040f0ee89f32916b6bb58e3c071dfae",
+                "reference": "950356de7040f0ee89f32916b6bb58e3c071dfae",
                 "shasum": ""
             },
             "require": {
@@ -1943,9 +1967,9 @@
                 "phpactor/source-code-filesystem": "~0.1"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.4"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
@@ -1970,7 +1994,7 @@
                 }
             ],
             "description": "Source Code Filesystem Extension",
-            "time": "2019-03-03T13:37:45+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpactor/text-document",
@@ -1978,12 +2002,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/text-document.git",
-                "reference": "f2dbdf776f3cb78378dcc3b4e8cd9a6d795fd70a"
+                "reference": "78377fe0a35388dde5f9f3cf7fd613696d4951c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/text-document/zipball/f2dbdf776f3cb78378dcc3b4e8cd9a6d795fd70a",
-                "reference": "f2dbdf776f3cb78378dcc3b4e8cd9a6d795fd70a",
+                "url": "https://api.github.com/repos/phpactor/text-document/zipball/78377fe0a35388dde5f9f3cf7fd613696d4951c7",
+                "reference": "78377fe0a35388dde5f9f3cf7fd613696d4951c7",
                 "shasum": ""
             },
             "require": {
@@ -1991,11 +2015,11 @@
                 "webmozart/path-util": "^2.3"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "infection/infection": "^0.11.4",
                 "phpactor/test-utils": "^1.0",
-                "phpstan/phpstan": "^0.10.7",
-                "phpunit/phpunit": "^7.5"
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "library",
             "extra": {
@@ -2019,7 +2043,7 @@
                 }
             ],
             "description": "Collection of value objects for representing and referencing text documents",
-            "time": "2019-03-17T11:44:52+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpactor/worse-reference-finder-extension",
@@ -2125,12 +2149,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/worse-reflection.git",
-                "reference": "49c72e7101ed71d9e087dcf651c622294cc87a0f"
+                "reference": "f57aeecc1544c3cde634319ec1440e3616a68727"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/worse-reflection/zipball/49c72e7101ed71d9e087dcf651c622294cc87a0f",
-                "reference": "49c72e7101ed71d9e087dcf651c622294cc87a0f",
+                "url": "https://api.github.com/repos/phpactor/worse-reflection/zipball/f57aeecc1544c3cde634319ec1440e3616a68727",
+                "reference": "f57aeecc1544c3cde634319ec1440e3616a68727",
                 "shasum": ""
             },
             "require": {
@@ -2142,12 +2166,12 @@
                 "psr/log": "^1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "phpactor/class-to-file": "~0.1",
                 "phpactor/test-utils": "@dev",
                 "phpbench/phpbench": "dev-master",
-                "phpstan/phpstan": "^0.8.5",
-                "phpunit/phpunit": "^6.0@stable",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0",
                 "symfony/filesystem": "^3.3"
             },
             "type": "library",
@@ -2172,7 +2196,7 @@
                 }
             ],
             "description": "Lazy AST reflector that is much worse than better",
-            "time": "2019-03-17T10:53:43+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpactor/worse-reflection-extension",
@@ -2180,12 +2204,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/worse-reflection-extension.git",
-                "reference": "c660068ef2f67ebedbb6c855cb33cdcfc346d572"
+                "reference": "ae009270f9fb73d25fca213cdf9fec0ddacb19f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/worse-reflection-extension/zipball/c660068ef2f67ebedbb6c855cb33cdcfc346d572",
-                "reference": "c660068ef2f67ebedbb6c855cb33cdcfc346d572",
+                "url": "https://api.github.com/repos/phpactor/worse-reflection-extension/zipball/ae009270f9fb73d25fca213cdf9fec0ddacb19f0",
+                "reference": "ae009270f9fb73d25fca213cdf9fec0ddacb19f0",
                 "shasum": ""
             },
             "require": {
@@ -2197,9 +2221,9 @@
                 "phpactor/worse-reflection": "~0.1"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
-                "phpstan/phpstan": "^0.10.5",
-                "phpunit/phpunit": "^7.3"
+                "friendsofphp/php-cs-fixer": "~2.15.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "phpactor-extension",
             "extra": {
@@ -2224,7 +2248,7 @@
                 }
             ],
             "description": "Worse Reflection",
-            "time": "2019-03-17T11:32:33+00:00"
+            "time": "2019-08-24T14:04:06+00:00"
         },
         {
             "name": "phpbench/container",
@@ -2368,28 +2392,29 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "2.0.x-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "abcc70409ddfb310a8cb41ef0c2e857425438cf4"
+                "reference": "d7e7810940c78f3343420f76adf92dc437b7a557"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/abcc70409ddfb310a8cb41ef0c2e857425438cf4",
-                "reference": "abcc70409ddfb310a8cb41ef0c2e857425438cf4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/d7e7810940c78f3343420f76adf92dc437b7a557",
+                "reference": "d7e7810940c78f3343420f76adf92dc437b7a557",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2414,9 +2439,12 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-12-14T11:32:19+00:00"
+            "time": "2019-07-02T07:43:30+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -2513,27 +2541,28 @@
         },
         {
             "name": "symfony/console",
-            "version": "dev-master",
+            "version": "4.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f6f44ce1c9513a37b8826ce7f3edd26d6ab7bf09"
+                "reference": "8372ce7fd5fdc8a9e90cc47c65085e1fd8128492"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f6f44ce1c9513a37b8826ce7f3edd26d6ab7bf09",
-                "reference": "f6f44ce1c9513a37b8826ce7f3edd26d6ab7bf09",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8372ce7fd5fdc8a9e90cc47c65085e1fd8128492",
+                "reference": "8372ce7fd5fdc8a9e90cc47c65085e1fd8128492",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/contracts": "^1.1",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.8"
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/service-contracts": "^1.1"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
-                "symfony/event-dispatcher": "<4.3",
+                "symfony/event-dispatcher": "<4.3|>=5",
+                "symfony/lock": "<4.4",
                 "symfony/process": "<3.3"
             },
             "provide": {
@@ -2541,12 +2570,12 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
                 "symfony/event-dispatcher": "^4.3",
-                "symfony/lock": "~3.4|~4.0",
-                "symfony/process": "~3.4|~4.0",
-                "symfony/var-dumper": "^4.3"
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/var-dumper": "^4.3|^5.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -2557,7 +2586,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -2584,78 +2613,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-30T07:40:00+00:00"
-        },
-        {
-            "name": "symfony/contracts",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/contracts.git",
-                "reference": "5c73fbfcbabb1722084cd95b819ce18389a7e5ea"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/contracts/zipball/5c73fbfcbabb1722084cd95b819ce18389a7e5ea",
-                "reference": "5c73fbfcbabb1722084cd95b819ce18389a7e5ea",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3"
-            },
-            "require-dev": {
-                "psr/cache": "^1.0",
-                "psr/container": "^1.0",
-                "symfony/polyfill-intl-idn": "^1.10"
-            },
-            "suggest": {
-                "psr/cache": "When using the Cache contracts",
-                "psr/container": "When using the Service contracts",
-                "symfony/cache-contracts-implementation": "",
-                "symfony/event-dispatcher-implementation": "",
-                "symfony/http-client-contracts-implementation": "",
-                "symfony/service-contracts-implementation": "",
-                "symfony/translation-contracts-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\": ""
-                },
-                "exclude-from-classmap": [
-                    "**/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A set of abstractions extracted out of the Symfony components",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "time": "2019-04-02T10:06:39+00:00"
+            "time": "2019-08-26T09:00:56+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -2663,12 +2621,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "acf99758b1df8e9295e6b85aa69f294565c9fedb"
+                "reference": "00e3a6ddd723b8bcfe4f2a1b6f82b98eeeb51516"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/acf99758b1df8e9295e6b85aa69f294565c9fedb",
-                "reference": "acf99758b1df8e9295e6b85aa69f294565c9fedb",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/00e3a6ddd723b8bcfe4f2a1b6f82b98eeeb51516",
+                "reference": "00e3a6ddd723b8bcfe4f2a1b6f82b98eeeb51516",
                 "shasum": ""
             },
             "require": {
@@ -2705,20 +2663,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-04T21:34:32+00:00"
+            "time": "2019-08-20T13:31:17+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "dev-master",
+            "version": "4.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "93e27e6111470949885d5486ad2fa0bd3bb3b0b5"
+                "reference": "6641e4e4acb1f316a1b15f761c69e52e84f95a19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/93e27e6111470949885d5486ad2fa0bd3bb3b0b5",
-                "reference": "93e27e6111470949885d5486ad2fa0bd3bb3b0b5",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/6641e4e4acb1f316a1b15f761c69e52e84f95a19",
+                "reference": "6641e4e4acb1f316a1b15f761c69e52e84f95a19",
                 "shasum": ""
             },
             "require": {
@@ -2727,7 +2685,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -2754,7 +2712,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-28T11:28:31+00:00"
+            "time": "2019-08-22T13:18:41+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2762,12 +2720,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "82ebae02209c21113908c229e9883c419720738a"
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
-                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
                 "shasum": ""
             },
             "require": {
@@ -2779,7 +2737,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -2796,12 +2754,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -2812,7 +2770,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2820,12 +2778,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
-                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17",
                 "shasum": ""
             },
             "require": {
@@ -2837,7 +2795,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -2871,7 +2829,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -2879,12 +2837,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "d1fb4abcc0c47be136208ad9d68bf59f1ee17abd"
+                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/d1fb4abcc0c47be136208ad9d68bf59f1ee17abd",
-                "reference": "d1fb4abcc0c47be136208ad9d68bf59f1ee17abd",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/2ceb49eaccb9352bff54d22570276bb75ba4a188",
+                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188",
                 "shasum": ""
             },
             "require": {
@@ -2893,7 +2851,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -2929,20 +2887,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "dev-master",
+            "version": "4.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "483b38ff95689915ddc1feeed1cbce6422467b02"
+                "reference": "0c03768430b6df1828f59e3ede786e93fa49d03d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/483b38ff95689915ddc1feeed1cbce6422467b02",
-                "reference": "483b38ff95689915ddc1feeed1cbce6422467b02",
+                "url": "https://api.github.com/repos/symfony/process/zipball/0c03768430b6df1828f59e3ede786e93fa49d03d",
+                "reference": "0c03768430b6df1828f59e3ede786e93fa49d03d",
                 "shasum": ""
             },
             "require": {
@@ -2951,7 +2909,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -2978,7 +2936,65 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-01T13:29:45+00:00"
+            "time": "2019-08-26T09:00:56+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
+                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-08-20T14:44:19+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -2986,12 +3002,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996"
+                "reference": "3dc414b7db30695bae671a1d86013d03f4ae9834"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/212a27b731e5bfb735679d1ffaac82bd6a1dc996",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/3dc414b7db30695bae671a1d86013d03f4ae9834",
+                "reference": "3dc414b7db30695bae671a1d86013d03f4ae9834",
                 "shasum": ""
             },
             "require": {
@@ -3037,7 +3053,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-25T07:48:46+00:00"
+            "time": "2019-08-20T13:31:17+00:00"
         },
         {
             "name": "twig/twig",
@@ -3045,28 +3061,28 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "e3470f5e4f7d5938c5a5161a041febfd6689c311"
+                "reference": "38341bbefdaf496e0752c90b053c54ed23d57f98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/e3470f5e4f7d5938c5a5161a041febfd6689c311",
-                "reference": "e3470f5e4f7d5938c5a5161a041febfd6689c311",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/38341bbefdaf496e0752c90b053c54ed23d57f98",
+                "reference": "38341bbefdaf496e0752c90b053c54ed23d57f98",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
                 "psr/container": "^1.0",
-                "symfony/debug": "^2.7",
-                "symfony/phpunit-bridge": "^3.4.19|^4.1.8"
+                "symfony/debug": "^3.4|^4.2",
+                "symfony/phpunit-bridge": "^4.4@dev|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.12-dev"
                 }
             },
             "autoload": {
@@ -3084,19 +3100,19 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
+                    "role": "Lead Developer",
                     "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                },
-                {
-                    "name": "Armin Ronacher",
-                    "email": "armin.ronacher@active-4.com",
-                    "role": "Project Founder"
+                    "homepage": "http://fabien.potencier.org"
                 },
                 {
                     "name": "Twig Team",
-                    "homepage": "https://twig.symfony.com/contributors",
-                    "role": "Contributors"
+                    "role": "Contributors",
+                    "homepage": "https://twig.symfony.com/contributors"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "role": "Project Founder",
+                    "email": "armin.ronacher@active-4.com"
                 }
             ],
             "description": "Twig, the flexible, fast, and secure template language for PHP",
@@ -3104,20 +3120,20 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2019-04-02T15:21:06+00:00"
+            "time": "2019-08-21T05:13:01+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
                 "shasum": ""
             },
             "require": {
@@ -3125,8 +3141,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
             "extra": {
@@ -3155,7 +3170,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2019-08-24T08:43:50+00:00"
         },
         {
             "name": "webmozart/glob",


### PR DESCRIPTION
Released Phpactor [0.13.2](https://github.com/phpactor/phpactor/releases/tag/0.13.2) and applied my patches(https://github.com/phpactor/docblock/pull/3, https://github.com/phpactor/docblock/pull/5).

@kermorgant close https://github.com/emacs-php/phpactor.el/pull/135
I'm merging this branch into the `develop`, so please send fixes for the 0.13 RPC interface incompatible as PR to the `develop` branch. Thank you!