### PR TITLE
[IMP] Make `phpactor-import-class' actually interactive

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -701,10 +701,14 @@ function."
     (apply #'phpactor-action-dispatch (phpactor--rpc "goto_definition" arguments))))
 
 ;;;###autoload
-(defun phpactor-import-class (name)
-  "Execute Phpactor RPC import_class command for class NAME."
+(defun phpactor-import-class (&optional name)
+  "Execute Phpactor RPC import_class command for class NAME.
+
+If called interactively, treat current symbol under cursor as NAME.
+If any region is active, it takes precedence over symbol at point."
   (interactive)
-  (let ((arguments (phpactor--command-argments :source :offset :path)))
+  (let ((arguments (phpactor--command-argments :source :offset :path))
+        (name (or name (if (region-active-p) (buffer-substring (point) (mark)) (symbol-at-point)))))
     (apply #'phpactor-action-dispatch (phpactor--rpc "import_class" (append arguments (list :name name))))))
 
 ;;;###autoload


### PR DESCRIPTION
Despite being declared as `(interactive)`, the function can't be called
as such since there's no `NAME` provided to it. This patch aims to
improve the usability of this function, since now explicit `NAME` arg
could be omitted.

As of now, the function looks up for `NAME` in this particular order:

* a `NAME` argument explicitly passed to function -- to use in code,
* contents of current region, if any -- interactive usage,
* a symbol on a current cursor position -- interactive usage.