### PR TITLE
Search phpstan executable from exec-path

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -117,7 +117,15 @@ of GitHub.")
 
 (defun phpactor--find-executable ()
   "Return path to Phpactor executable file."
-  (let ((vendor-executable (f-join phpactor-install-directory "vendor/bin/phpactor")))
+  (let* (target
+         (vendor-executable
+          (cond
+           ((progn
+              (setq target (f-join phpactor-install-directory "vendor/bin/phpactor"))
+              (file-executable-p target))
+            target)
+           ((setq target (executable-find "phpactor"))
+            target))))
     (if (file-exists-p vendor-executable)
         vendor-executable
       (warn "Phpactor not found.  Please run `phpactor-install-or-update' command")

--- a/phpactor.el
+++ b/phpactor.el
@@ -126,10 +126,9 @@ of GitHub.")
             target)
            ((setq target (executable-find "phpactor"))
             target))))
-    (if (file-exists-p vendor-executable)
-        vendor-executable
-      (warn "Phpactor not found.  Please run `phpactor-install-or-update' command")
-      nil)))
+    (unless vendor-executable
+      (warn "Phpactor not found.  Please run `phpactor-install-or-update' command"))
+    vendor-executable))
 
 (defcustom phpactor-executable (phpactor--find-executable)
   "Path to phpactor executable.


### PR DESCRIPTION
現在、phpstanをグローバルにインストールしている場合にバイナリファ
イルを見つけられません。
find-executableによる検索を追加しました。