### PR TITLE
throw error when phpactor-executable is not set

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -234,6 +234,8 @@ have to ensure a compatible version of phpactor is used."
       (setq default-directory cwd)
       (erase-buffer)
       (insert json)
+      (unless phpactor-executable
+        (error "`phpactor-executable' is not set.  Please run `phpactor-install-or-update' command"))
       (call-process-region (point-min) (point-max) phpactor-executable nil output nil "rpc" (format "--working-dir=%s" default-directory))
       (phpactor--parse-json output))))
 


### PR DESCRIPTION
現在phpactor-executableが何らかの理由でnilの場合でも処理を続けて
しまっています。
ワーニングは出ていますが、ユーザーはコマンドを実行した際のエラー
をより注意深く見ると思います。

現在はnilのままcall-process-regionを呼びだして、
(wrong-type-argument stringp nil)が発生しています。
起こっているエラーが分かりやすいように、エラーを投げるように修正しました。