### PR TITLE
Do not call locate-user-emacs-file when compiling

### DIFF
--- a/phpactor.el
+++ b/phpactor.el
@@ -68,8 +68,7 @@
 
 ;;;###autoload
 (defcustom phpactor-install-directory
-  (eval-when-compile
-    (expand-file-name (locate-user-emacs-file "phpactor/")))
+  (expand-file-name (locate-user-emacs-file "phpactor/"))
   "Directory for setup Phactor.  (default `~/.emacs.d/phpactor/')."
   :type 'directory)
 


### PR DESCRIPTION
The default value of phpactor-install-directory is relative to the user's user-emacs-directory. Using eval-when-compile here hardcodes the wrong directory if a separate build user is used.